### PR TITLE
feat(authenticate): open authenticate window

### DIFF
--- a/examples/app.html
+++ b/examples/app.html
@@ -63,7 +63,7 @@
         e.preventDefault();
 
         Livestax.authenticate.start({
-          url: "http://www.example.com",
+          url: "/examples/auth.html",
           provider: "Dummy",
           callback: function(code) {
             document.getElementById("auth-output").innerHTML = "Authentication code: " + code;

--- a/examples/auth.html
+++ b/examples/auth.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+    <script src="//assets.livestax.com/livestax-0.3.0.min.js"></script>
+  </head>
+
+  <h3>This window will automatically close</h3>
+</html>

--- a/examples/auth.html
+++ b/examples/auth.html
@@ -5,4 +5,8 @@
   </head>
 
   <h3>This window will automatically close</h3>
+
+  <script>
+    Livestax.authenticate.respond("dummy_code");
+  </script>
 </html>

--- a/scripts/actions/authenticate_actions.js
+++ b/scripts/actions/authenticate_actions.js
@@ -1,0 +1,17 @@
+"use strict";
+
+var AppDispatcher = require("../dispatchers/app_dispatcher");
+var ActionTypes = require("../constants/app_constants").ActionTypes;
+
+var AuthenticateActions = {
+  openWindow(data) {
+    AppDispatcher.dispatch({
+      type: ActionTypes.OPEN_AUTHENTICATE_WINDOW,
+      payload: {
+        url: data
+      }
+    });
+  }
+};
+
+module.exports = AuthenticateActions;

--- a/scripts/components/app_iframe.jsx
+++ b/scripts/components/app_iframe.jsx
@@ -7,6 +7,7 @@ var KeyValueStore = require("../stores/key_value_store");
 var FlashMessageStore = require("../stores/flash_message_store");
 var MenuStore = require("../stores/menu_store");
 var DialogStore = require("../stores/dialog_store");
+var AuthenticateStore = require("../stores/authenticate_store");
 var Projections = require("../projections/app_projections");
 var Immutable = require("immutable");
 
@@ -23,6 +24,7 @@ var AppIframe = React.createClass({
     FlashMessageStore.addChangeListener(this._onFlashMessageChange);
     MenuStore.addChangeListener(this._onMenuChange);
     DialogStore.addChangeListener(this._onDialogChange);
+    AuthenticateStore.addChangeListener(this._onAuthenticateChange);
   },
 
   componentWillUnmount() {
@@ -31,6 +33,7 @@ var AppIframe = React.createClass({
     FlashMessageStore.removeChangeListener(this._onFlashMessageChange);
     MenuStore.removeChangeListener(this._onMenuChange);
     DialogStore.removeChangeListener(this._onDialogChange);
+    AuthenticateStore.removeChangeListener(this._onAuthenticateChange);
   },
 
   componentWillUpdate() {
@@ -113,6 +116,19 @@ var AppIframe = React.createClass({
       }
     });
     this._postMessage(payload);
+  },
+
+  _onAuthenticateChange(e) {
+    if(e && e.type === "response") {
+      var payload = Immutable.Map({
+        type: "authenticate",
+        payload: {
+          type: "respond",
+          data: e.data
+        }
+      });
+      this._postMessage(payload);
+      }
   },
 
   render() {

--- a/scripts/components/authenticate_panel.jsx
+++ b/scripts/components/authenticate_panel.jsx
@@ -3,12 +3,17 @@
 var React = require("react");
 var CollapsiblePanel = require("./lib/collapsible_panel");
 var AuthenticateStore = require("../stores/authenticate_store");
+var AuthenticateActions = require("../actions/authenticate_actions");
 var EmptyPanel = require("./empty_panel");
 
 var getState = () => {
   return {
     authRequest: AuthenticateStore.getAuthRequest()
   };
+};
+
+var openAuthPage = (url) => {
+  AuthenticateActions.openWindow(url);
 };
 
 const AuthenticatePanel = React.createClass({
@@ -41,6 +46,15 @@ const AuthenticatePanel = React.createClass({
         <div className="panel panel-default panel-message dialog-message">
           <div className="panel-body">
             <h3><strong>Login with {authRequest.get("provider")}</strong></h3>
+          </div>
+
+          <div className="panel-footer" style={{background: "white"}}>
+            <div className="btn-group btn-group-justified">
+              <a className="btn btn-primary"
+                onClick={openAuthPage.bind(this, authRequest.get("url"))}>
+                Authenticate
+              </a>
+            </div>
           </div>
         </div>
       </CollapsiblePanel>

--- a/scripts/constants/app_constants.js
+++ b/scripts/constants/app_constants.js
@@ -16,7 +16,8 @@ module.exports = {
     DELETE_HISTORY_ITEM: null,
     CLEAR_HISTORY: null,
     DIALOG_INTERACTION: null,
-    CLEAR_DIALOG: null
+    CLEAR_DIALOG: null,
+    OPEN_AUTHENTICATE_WINDOW: null
   }),
   ChangeTypes: keyMirror({
     APP_CHANGE: null,

--- a/scripts/incidents/authenticate_incident.js
+++ b/scripts/incidents/authenticate_incident.js
@@ -1,0 +1,9 @@
+"use strict";
+
+class AuthenticateIncident {
+  openWindow(url) {
+    window.open(url);
+  }
+}
+
+module.exports = new AuthenticateIncident();

--- a/scripts/incidents/authenticate_incident.js
+++ b/scripts/incidents/authenticate_incident.js
@@ -1,8 +1,30 @@
 "use strict";
 
 class AuthenticateIncident {
+  constructor() {
+    this.poll = undefined;
+  }
+
   openWindow(url) {
-    window.open(url);
+    var popup = window.open(url);
+
+    var ping = () => {
+      this.poll = setInterval(
+        this.sendPostMessage,
+        1000,
+        popup
+      );
+    };
+    ping();
+  }
+
+  sendPostMessage(popup) {
+    popup.postMessage({type: "livestax:ping"}, "*");
+  }
+
+  responded() {
+    clearInterval(this.poll);
+    this.poll = null;
   }
 }
 

--- a/scripts/stores/authenticate_store.js
+++ b/scripts/stores/authenticate_store.js
@@ -51,7 +51,14 @@ class AuthenticateStore extends EventEmitter {
 
   _receivePostMessage(data) {
     if(data.type === "authenticate") {
-      this.setState(["authRequest"], Immutable.fromJS(data.payload.data));
+      if(data.payload.type === "response") {
+        AuthenticateIncident.responded();
+        this.reset();
+        this.emitChange(data.payload);
+
+      } else {
+        this.setState(["authRequest"], Immutable.fromJS(data.payload.data));
+      }
     }
   }
 

--- a/scripts/stores/authenticate_store.js
+++ b/scripts/stores/authenticate_store.js
@@ -6,6 +6,7 @@ var Constants = require("../constants/app_constants");
 var ActionTypes = Constants.ActionTypes;
 var CHANGE_EVENT = Constants.ChangeTypes.AUTHENTICATE_CHANGE;
 var Immutable = require("immutable");
+var AuthenticateIncident = require("../incidents/authenticate_incident");
 
 class AuthenticateStore extends EventEmitter {
   constructor() {
@@ -62,6 +63,9 @@ class AuthenticateStore extends EventEmitter {
         break;
         case ActionTypes.RECEIVE_APP_CONFIGURATION:
           this.reset();
+        break;
+        case ActionTypes.OPEN_AUTHENTICATE_WINDOW:
+          AuthenticateIncident.openWindow(action.payload.url)
         break;
       }
     });

--- a/test/components/app_iframe_test.js
+++ b/test/components/app_iframe_test.js
@@ -10,6 +10,7 @@ var MessageActions = require("../../scripts/actions/message_actions");
 var FlashActions = require("../../scripts/actions/flash_actions");
 var MenuActions = require("../../scripts/actions/menu_actions");
 var DialogActions = require("../../scripts/actions/dialog_actions");
+var AppActions = require("../../scripts/actions/app_actions");
 var Immutable = require("immutable");
 
 describe("AppIframe", () => {
@@ -137,12 +138,34 @@ describe("AppIframe", () => {
         DialogActions.dialogInteraction({title: "no"});
       });
 
-      it("sends a trigger postMessage", () => {
+      it("sends a dialog postMessage", () => {
         expect(contentWindow.postMessage).to.have.been.calledWith({
           type: "dialog",
           payload: {
             type: "action",
             data: "no"
+          }
+        });
+      });
+    });
+
+    describe("when an authenticate response, post message is received", () => {
+      beforeEach(() => {
+        AppActions.receivePostMessage({
+          type: "authenticate",
+          payload: {
+            type: "response",
+            data: "dummy code"
+          }
+        })
+      });
+
+      it("sends an authenticate postMessage", () => {
+        expect(contentWindow.postMessage).to.have.been.calledWith({
+          type: "authenticate",
+          payload: {
+            type: "respond",
+            data: "dummy code"
           }
         });
       });

--- a/test/components/authenticate_test.js
+++ b/test/components/authenticate_test.js
@@ -6,6 +6,7 @@ var Immutable = require("immutable");
 var TestUtils = React.addons.TestUtils;
 var AuthenticateStore = require("../../scripts/stores/authenticate_store");
 var AuthenticatePanel = require("../../scripts/components/authenticate_panel");
+var AuthenticateActions = require("../../scripts/actions/authenticate_actions");
 
 describe("AuthenticatePanel", () => {
   var instance;
@@ -28,6 +29,8 @@ describe("AuthenticatePanel", () => {
   });
 
   describe("when an authenticate message is received", () => {
+    var authMessage;
+
     beforeEach(() => {
       AuthenticateStore.replaceState(Immutable.fromJS({
         authRequest: {
@@ -35,12 +38,34 @@ describe("AuthenticatePanel", () => {
           url: "http://www.example.com"
         }
       }));
+
+      authMessage = TestUtils.findRenderedDOMComponentWithClass(instance, "dialog-message");
     });
 
     it("renders the auth provider", () => {
-      var authMessage = TestUtils.findRenderedDOMComponentWithClass(instance, "dialog-message");
       var panelBody = TestUtils.findRenderedDOMComponentWithClass(authMessage, "panel-body");
       expect(panelBody.getDOMNode().children[0].textContent).to.eql("Login with Third party service");
+    });
+
+    describe("Authenticate button", () => {
+      var authButton;
+
+      beforeEach(() => {
+        var panelFooter = TestUtils.findRenderedDOMComponentWithClass(authMessage, "panel-footer");
+        authButton = TestUtils.findRenderedDOMComponentWithClass(panelFooter, "btn");
+      });
+
+      it("renders an 'Authenticate' button", () => {
+        expect(authButton.getDOMNode().textContent).to.eql("Authenticate");
+      });
+
+      describe("when the 'Authenticate` button is clicked", () => {
+        it("triggers an `openWindow` action", () => {
+          sinon.spy(AuthenticateActions, "openWindow");
+          TestUtils.Simulate.click(authButton.getDOMNode());
+          expect(AuthenticateActions.openWindow).to.have.been.calledWith("http://www.example.com");
+        });
+      });
     });
   });
 });

--- a/test/incidents/authenticate_incident_test.js
+++ b/test/incidents/authenticate_incident_test.js
@@ -1,0 +1,24 @@
+"use strict";
+
+require("../test_helper");
+
+var AuthenticateIncident = require("../../scripts/incidents/authenticate_incident");
+
+describe("AuthenticateIncident", () => {
+  describe("#openWindow", () => {
+    var _open = window.open;
+
+    beforeEach(() => {
+      window.open = sinon.stub();
+    });
+
+    afterEach(() => {
+      window.open = _open;
+    });
+
+    it("opens the url in a new window", () => {
+      AuthenticateIncident.openWindow("http://www.example.com");
+      expect(window.open).to.have.been.calledWith("http://www.example.com");
+    });
+  });
+});

--- a/test/incidents/authenticate_incident_test.js
+++ b/test/incidents/authenticate_incident_test.js
@@ -7,18 +7,41 @@ var AuthenticateIncident = require("../../scripts/incidents/authenticate_inciden
 describe("AuthenticateIncident", () => {
   describe("#openWindow", () => {
     var _open = window.open;
+    var clock;
 
     beforeEach(() => {
       window.open = sinon.stub();
+      clock = sinon.useFakeTimers();
+      sinon.stub(AuthenticateIncident, "sendPostMessage");
     });
 
     afterEach(() => {
       window.open = _open;
+      clock.restore();
+      AuthenticateIncident.sendPostMessage.restore();
     });
 
     it("opens the url in a new window", () => {
       AuthenticateIncident.openWindow("http://www.example.com");
       expect(window.open).to.have.been.calledWith("http://www.example.com");
+
+    });
+
+    it("calls sendPostMessage once per second", () => {
+      AuthenticateIncident.openWindow("http://www.example.com");
+      clock.tick(3000);
+      expect(AuthenticateIncident.sendPostMessage).to.be.calledThrice;
+    });
+  });
+
+  describe("#sendPostMessage", () => {
+    it("sends a livestax:ping message to popoup", () => {
+      var fakePopup = {
+        postMessage: sinon.stub()
+      };
+
+      AuthenticateIncident.sendPostMessage(fakePopup);
+      expect(fakePopup.postMessage).to.have.been.calledWith({type: "livestax:ping"}, "*");
     });
   });
 });

--- a/test/stores/authenticate_store_test.js
+++ b/test/stores/authenticate_store_test.js
@@ -34,6 +34,43 @@ describe("AuthenticateStore", () => {
         expect(callback).to.have.been.called;
       });
     });
+
+    describe("when an authenticate message of type `response` is received", () => {
+      var responsePostMessage;
+
+      beforeEach(() => {
+        AuthenticateStore.setState(["authRequest"], {
+          provider: "Third Party Service",
+          url: "http://www.example.com"
+        });
+
+        responsePostMessage = {
+          type: "authenticate",
+          payload: {
+            type: "response",
+          }
+        };
+      });
+
+      it("resets the authRequest property to null", () => {
+        expect(AuthenticateStore.getAuthRequest()).to.not.eql(null);
+        AppActions.receivePostMessage(responsePostMessage);
+        expect(AuthenticateStore.getAuthRequest()).to.eql(null);
+      });
+
+      it("triggers a change event", () => {
+        var callback = sinon.stub();
+        AuthenticateStore.addChangeListener(callback);
+        AppActions.receivePostMessage(responsePostMessage);
+        expect(callback).to.have.been.called;
+      });
+
+      it("triggers AuthenticateIncident.responded", () => {
+        sinon.spy(AuthenticateIncident, "responded");
+        AppActions.receivePostMessage(responsePostMessage);
+        expect(AuthenticateIncident.responded).to.have.been.called;
+      });
+    });
   });
 
   describe("when an app configuration action is received", () => {

--- a/test/stores/authenticate_store_test.js
+++ b/test/stores/authenticate_store_test.js
@@ -3,7 +3,9 @@
 require("../test_helper");
 var Immutable = require("immutable");
 var AuthenticateStore = require("../../scripts/stores/authenticate_store");
+var AuthenticateIncident = require("../../scripts/incidents/authenticate_incident");
 var AppActions = require("../../scripts/actions/app_actions");
+var AuthenticateActions = require("../../scripts/actions/authenticate_actions");
 
 describe("AuthenticateStore", () => {
   var postMessage = {
@@ -45,5 +47,20 @@ describe("AuthenticateStore", () => {
       AppActions.receiveAppConfiguration(Immutable.fromJS({}));
       expect(AuthenticateStore.getAuthRequest()).to.eql(null);
     });
+  });
+
+  describe("when an open authenticate window action is received", () => {
+    beforeEach(() => {
+      sinon.stub(AuthenticateIncident, "openWindow");
+    });
+
+    afterEach(() => {
+      AuthenticateIncident.openWindow.restore();
+    });
+
+     it("triggers an `openWindow` incident", () => {
+       AuthenticateActions.openWindow("http://www.example.com");
+       expect(AuthenticateIncident.openWindow).to.have.been.calledWith("http://www.example.com");
+     });
   });
 });


### PR DESCRIPTION
On receiving an `authRequest`, the `AuthenticatePanel` now displays an
`Authenticate` button. When this button is clicked an
`OPEN_AUTHENTICATE_WINDOW` action is triggered.

The `AuthenticateStore` registers an interest in
`OPEN_AUTHENTICATE_WINDOW` actions, and on receiving such an action it
triggers an `openWindow` `AuthenticateIncident` which will open the
authenticate url in a new window.