### PR TITLE
feat(authenticate): add clear button to panel

### DIFF
--- a/scripts/actions/authenticate_actions.js
+++ b/scripts/actions/authenticate_actions.js
@@ -11,6 +11,12 @@ var AuthenticateActions = {
         url: data
       }
     });
+  },
+
+  clearRequest() {
+    AppDispatcher.dispatch({
+      type: ActionTypes.CLEAR_AUTH_REQUEST
+    });
   }
 };
 

--- a/scripts/components/authenticate_panel.jsx
+++ b/scripts/components/authenticate_panel.jsx
@@ -5,6 +5,7 @@ var CollapsiblePanel = require("./lib/collapsible_panel");
 var AuthenticateStore = require("../stores/authenticate_store");
 var AuthenticateActions = require("../actions/authenticate_actions");
 var EmptyPanel = require("./empty_panel");
+var PanelToolbar = require("./lib/panel_toolbar");
 
 var getState = () => {
   return {
@@ -31,6 +32,10 @@ const AuthenticatePanel = React.createClass({
     this.replaceState(getState());
   },
 
+  clear() {
+    AuthenticateActions.clearRequest();
+  },
+
   render() {
     var authRequest = this.state.authRequest;
 
@@ -43,6 +48,13 @@ const AuthenticatePanel = React.createClass({
 
     return (
       <CollapsiblePanel heading="Authentication">
+        <PanelToolbar>
+          <div className="panel-toolbar-actions">
+            <span className="label label-danger clear-auth pull-right" onClick={this.clear}>
+              Clear
+            </span>
+          </div>
+        </PanelToolbar>
         <div className="panel panel-default panel-message dialog-message">
           <div className="panel-body">
             <h3><strong>Login with {authRequest.get("provider")}</strong></h3>

--- a/scripts/components/authenticate_panel.jsx
+++ b/scripts/components/authenticate_panel.jsx
@@ -62,7 +62,11 @@ const AuthenticatePanel = React.createClass({
 
           <div className="panel-footer" style={{background: "white"}}>
             <div className="btn-group btn-group-justified">
-              <a className="btn btn-primary"
+              <a className="btn btn-primary-inverse cancel-btn"
+                onClick={this.clear}>
+                Cancel
+              </a>
+              <a className="btn btn-primary auth-btn"
                 onClick={openAuthPage.bind(this, authRequest.get("url"))}>
                 Authenticate
               </a>

--- a/scripts/constants/app_constants.js
+++ b/scripts/constants/app_constants.js
@@ -17,7 +17,8 @@ module.exports = {
     CLEAR_HISTORY: null,
     DIALOG_INTERACTION: null,
     CLEAR_DIALOG: null,
-    OPEN_AUTHENTICATE_WINDOW: null
+    OPEN_AUTHENTICATE_WINDOW: null,
+    CLEAR_AUTH_REQUEST: null
   }),
   ChangeTypes: keyMirror({
     APP_CHANGE: null,

--- a/scripts/stores/authenticate_store.js
+++ b/scripts/stores/authenticate_store.js
@@ -72,7 +72,10 @@ class AuthenticateStore extends EventEmitter {
           this.reset();
         break;
         case ActionTypes.OPEN_AUTHENTICATE_WINDOW:
-          AuthenticateIncident.openWindow(action.payload.url)
+          AuthenticateIncident.openWindow(action.payload.url);
+        break;
+        case ActionTypes.CLEAR_AUTH_REQUEST:
+          this.reset();
         break;
       }
     });

--- a/test/components/authenticate_test.js
+++ b/test/components/authenticate_test.js
@@ -71,12 +71,36 @@ describe("AuthenticatePanel", () => {
       });
     });
 
+    describe("when the cancel button is clicked", () => {
+      var cancel;
+
+      beforeEach(() => {
+        cancel = TestUtils.findRenderedDOMComponentWithClass(instance, "cancel-btn");
+      });
+
+      it("clears the auth request", function() {
+        expect(AuthenticateStore.getAuthRequest()).to.not.eql(null);
+        TestUtils.Simulate.click(cancel.getDOMNode());
+        expect(AuthenticateStore.getAuthRequest()).to.eql(null);
+      });
+
+      it("renders a help message ", () => {
+        var help = TestUtils.scryRenderedDOMComponentsWithClass(instance, "help-message");
+        expect(help.length).to.eql(0);
+
+        TestUtils.Simulate.click(cancel.getDOMNode());
+
+        help = TestUtils.scryRenderedDOMComponentsWithClass(instance, "help-message");
+        expect(help.length).to.eql(1);
+      });
+    });
+
     describe("Authenticate button", () => {
       var authButton;
 
       beforeEach(() => {
         var panelFooter = TestUtils.findRenderedDOMComponentWithClass(authMessage, "panel-footer");
-        authButton = TestUtils.findRenderedDOMComponentWithClass(panelFooter, "btn");
+        authButton = TestUtils.findRenderedDOMComponentWithClass(panelFooter, "auth-btn");
       });
 
       it("renders an 'Authenticate' button", () => {

--- a/test/components/authenticate_test.js
+++ b/test/components/authenticate_test.js
@@ -47,6 +47,30 @@ describe("AuthenticatePanel", () => {
       expect(panelBody.getDOMNode().children[0].textContent).to.eql("Login with Third party service");
     });
 
+    describe("when the clear button is clicked", () => {
+      var clear;
+
+      beforeEach(() => {
+        clear = TestUtils.findRenderedDOMComponentWithClass(instance, "clear-auth");
+      });
+
+      it("clears the auth request", function() {
+        expect(AuthenticateStore.getAuthRequest()).to.not.eql(null);
+        TestUtils.Simulate.click(clear.getDOMNode());
+        expect(AuthenticateStore.getAuthRequest()).to.eql(null);
+      });
+
+      it("renders a help message ", () => {
+        var help = TestUtils.scryRenderedDOMComponentsWithClass(instance, "help-message");
+        expect(help.length).to.eql(0);
+
+        TestUtils.Simulate.click(clear.getDOMNode());
+
+        help = TestUtils.scryRenderedDOMComponentsWithClass(instance, "help-message");
+        expect(help.length).to.eql(1);
+      });
+    });
+
     describe("Authenticate button", () => {
       var authButton;
 

--- a/test/stores/authenticate_store_test.js
+++ b/test/stores/authenticate_store_test.js
@@ -100,4 +100,17 @@ describe("AuthenticateStore", () => {
        expect(AuthenticateIncident.openWindow).to.have.been.calledWith("http://www.example.com");
      });
   });
+
+  describe("when a clear auth request action is received", () => {
+    it("resets the authRequest property to null", () => {
+      AuthenticateStore.setState(["authRequest"], {
+        provider: "Third Party Service",
+        url: "http://www.example.com"
+      });
+
+      expect(AuthenticateStore.getAuthRequest()).to.not.eql(null);
+      AuthenticateActions.clearRequest();
+      expect(AuthenticateStore.getAuthRequest()).to.eql(null);
+    });
+  });
 });


### PR DESCRIPTION
The `AuthenticatePanel` now displays a `PanelToolbar` containing a
`clear` button.

On clicking this button a `CLEAR_AUTH_REQUEST` action is raised which
the `AuthenticateStore` registers an interest in.

On receiving such an action the `AuthenticateStore` resets its internal
state, which will in turn clear the `AuthenticatePanel`.