### PR TITLE
fix(authenticate): switch const for var as not supported on safari

### DIFF
--- a/scripts/components/authenticate_panel.jsx
+++ b/scripts/components/authenticate_panel.jsx
@@ -17,7 +17,7 @@ var openAuthPage = (url) => {
   AuthenticateActions.openWindow(url);
 };
 
-const AuthenticatePanel = React.createClass({
+var AuthenticatePanel = React.createClass({
   getInitialState: getState,
 
   componentDidMount() {


### PR DESCRIPTION
Previously, The `AuthenticatePanel` assigned as a `const`, however, as
this is a part of upcoming ECMAScript Harmony specification, using the
`jsx?harmony` loader doesn't yet support this.

http://stackoverflow.com/questions/21237105/\
const-in-javascript-when-to-use-it-and-is-it-necessary